### PR TITLE
Add Aeternity node configuration

### DIFF
--- a/src/api/json/catalog.json
+++ b/src/api/json/catalog.json
@@ -54,6 +54,19 @@
       "url": "https://raw.githubusercontent.com/aerleon/aerleon/main/schemas/aerleon-policies.schema.json"
     },
     {
+      "name": "aenode config",
+      "description": "Aeternity node configuration",
+      "fileMatch": [
+        "aeternity.yml",
+        "aeternity.yaml",
+        "aeternity.json",
+        "*.aeternity.yml",
+        "*.aeternity.yaml",
+        "*.aeternity.json"
+      ],
+      "url": "https://raw.githubusercontent.com/aeternity/aeternity/master/apps/aeutils/priv/aeternity_config_schema.json"
+    },
+    {
       "name": ".agripparc.json",
       "description": "the Agrippa config file",
       "fileMatch": [".agripparc.json", "agripparc.json"],


### PR DESCRIPTION
The idea is to use aeternity.yaml schema in tools to validate node configuration. For example, in VS code you can install https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml and it would automatically pick yaml schema from schemastore. So, I'm proposing to register aenode configuration schema there.

I'm using a personal account instead of organisation as per https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md
`"name"` field is displayed in vscode status bar, so it shouldn't be very long.
I'm proposing to use `.aeternity.yml` as a suffix to allow auto detection of node configs, this needs to be documented in https://docs.aeternity.io/en/stable/configuration/.

If it is fine, I would do a PR to upstream repository.

blocked by https://github.com/aeternity/aeternity/pull/4293